### PR TITLE
fix up regex grammar enough to instantiate Lark parser

### DIFF
--- a/regex.lark
+++ b/regex.lark
@@ -1,29 +1,31 @@
-start		: regex
+%import common (INT, DECIMAL)
 
-regex		: regex_ere
-		| regex_bre
+start   	: regex
 
-regex_ere	: rex~{1,20}
+regex   	: regex_ere
+      		| regex_bre
 
-rex		: letter 
-          	| ( range
-            	| rex repetition
-            	| rex "|" rex
-            	| ( "(" rex ")" | "\\" num.dec)
-            	| "\\" ("w" | "W" | "<" | ">" | "b" | "B" | "`" | "'" | "r" | "n")
-            	| "(" rex+ ")" )
+regex_ere   	: rex ~ 1..20
 
-repetition	: "*" | "+" | "?"
-         	| "{" num.natural "}"
-         	| "{" num.natural "," "}"
-         	| "{" "," num.natural"}"
-         	| "{" num.natural "," num.natural "}"
+rex     	: LETTER 
+		| ( range
+		| rex repetition
+		| rex "|" rex
+		| ( "(" rex ")" | "\\" DECIMAL)
+		| "\\" ("w" | "W" | "<" | ">" | "b" | "B" | "`" | "'" | "r" | "n")
+		| "(" rex+ ")" )
 
-range		: "[" ("^" | "") range-elt* ("" | "$") "]"
+repetition  	: "*" | "+" | "?"
+		| "{" INT "}"
+		| "{" INT "," "}"
+		| "{" "," INT"}"
+		| "{" INT "," INT "}"
 
-letter		: [0-9a-z]
+range   	: "[" "^"? range_elt* "$"? "]"
 
-named-range-elt	: "[:alnum:]"
+LETTER  	: /[0-9a-zA-Z]/
+
+NAMED_RANGE_ELT : "[:alnum:]"
 		| "[:alpha:]"
 		| "[:cntrl:]"
 		| "[:digit:]"
@@ -35,8 +37,8 @@ named-range-elt	: "[:alnum:]"
 		| "[:upper:]"
 		| "[:xdigit:]"
 
-range-elt	: named-range-elt
-         	| letter
-         	| letter "-" letter
+range_elt   	: NAMED_RANGE_ELT
+            	| LETTER
+            	| LETTER "-" LETTER
 
-regex_bre	:
+regex_bre   	:


### PR DESCRIPTION
I've fixed up the grammar enough to instantiate the parser...

It's still not perfect but it works a bit 😄 

```python
In [1]: from lark import Lark

In [2]: with open("regex.lark") as f:
   ...:     grammar = Lark(f.read())
   ...:

In [4]: grammar.parse(r"[a-z]{4}[0-9]{1,2}")
Out[4]: Tree(start, [Tree(regex, [Tree(regex_ere, [Tree(rex, [Tree(rex, [Tree(range, [Tree(range_elt, [Token(LETTER, 'a'), Token(LETTER, 'z')])])]), Tree(repetition, [Token(INT, '4')])]), Tree(rex, [Tree(rex, [Tree(range, [Tree(range_elt, [Token(LETTER, '0'), Token(LETTER, '9')])])]), Tree(repetition, [Token(INT, '1'), Token(INT, '2')])])])])])

In [5]: grammar.parse(r"[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}")

UnexpectedCharacters: No terminal defined for '-' at line 1 col 9

[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}
        ^

Expecting: {'QMARK', 'LPAR', 'LETTER', 'LBRACE', 'LSQB', 'PLUS', 'VBAR', 'STAR', 'BACKSLASH'}
```